### PR TITLE
fix circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install ble-beacon
+    circup install adafruit_ble_beacon
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Resolves the following issue for this library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407 for this library

Editted by: tekktrik (removing auto-linking issue)