### PR TITLE
fix link in docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Introduction
 
 
 .. image:: https://readthedocs.org/projects/adafruit-circuitpython-ble-beacon/badge/?version=latest
-    :target: https://docs.circuitpython.org/projects/ble_beacon/en/latest/
+    :target: https://docs.circuitpython.org/projects/ble-beacon/en/latest/
     :alt: Documentation Status
 
 


### PR DESCRIPTION
Quick fix - link in badge pointed to 'ble_beacon' and not 'ble-beacon'.